### PR TITLE
The maximum payload size is 0x1df == 479 bytes, not 0x479 == 1145 bytes.

### DIFF
--- a/include/yaskawa_ethernet/udp/message.hpp
+++ b/include/yaskawa_ethernet/udp/message.hpp
@@ -107,7 +107,7 @@ struct Header {
 };
 
 constexpr std::size_t header_size      = 0x20;
-constexpr std::size_t max_payload_size = 0x479;
+constexpr std::size_t max_payload_size = 0x1df;
 
 struct RequestHeader : Header {
 	std::uint16_t command;


### PR DESCRIPTION
As stated in the title, the max_payload_size was too large. This commit reduces its value to the correct number.